### PR TITLE
Simplify zonal/regional GKE cluster configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,7 @@ To authenticate against a specific GKE cluster, use:
 
     # The name of the GKE cluster:
     gke_cluster_name: integration-worker-1
-    gke_cluster_region: europe-west1
-
-    # For a zonal cluster:
-    gke_cluster_zone: europe-west1-d
+    gke_cluster_location: europe-west1 # or a zonal cluster with europe-west1-d
 ```
 
 This corresponds to the `gcloud container clusters get-credentials $NAME --region $REGION` (or `--zone $ZONE`) `gcloud` command.

--- a/action.yml
+++ b/action.yml
@@ -30,19 +30,12 @@ inputs:
     required: false
     description: Name of a GKE Cluster to authenticate against
 
-  gke_cluster_zone:
+  gke_cluster_location:
     default: null
     required: false
     description: |
-      Zone of the **zonal** GKE Cluster to authenticate against.
-      Conflict with `gke_cluster_region`.
+      Location of the GKE cluster (zonal or regional) to authenticate against.
 
-  gke_cluster_region:
-    default: null
-    required: false
-    description: |
-      Region of the **regional** GKE Cluster to authenticate against.
-      Conflict with `gke_cluster_zone`.
 
   kustomize_version:
     required: false
@@ -65,22 +58,10 @@ runs:
       run: gcloud auth configure-docker
 
     - name: Authenticate for GKE (regional cluster)
-      shell: bash
-      if: ${{ inputs.gke_cluster_name != '' && inputs.gke_cluster_region != '' }}
-      run: |
-        gcloud container clusters get-credentials \
-          ${{ inputs.gke_cluster_name }} \
-          --project ${{ inputs.project_id }} \
-          --region ${{ inputs.gke_cluster_region }}
-
-    - name: Authenticate for GKE (zonal cluster)
-      shell: bash
-      if: ${{ inputs.gke_cluster_name != '' && inputs.gke_cluster_zone != '' }}
-      run: |
-        gcloud container clusters get-credentials \
-          ${{ inputs.gke_cluster_name }} \
-          --project ${{ inputs.project_id }} \
-          --zone ${{ inputs.gke_cluster_zone }}
+      uses: google-github-actions/get-gke-credentials@v0.4.0
+      with:
+        cluster_name: ${{ inputs.gke_cluster_name }}
+        location: ${{ inputs.gke_location }}
 
     - name: Show Google SDK info
       shell: bash


### PR DESCRIPTION
This now uses the `google-github-actions/get-gke-credentials@v0.4.0`, which does the same as before but it handles more easily regional/zonal clusters, without having to really select one or the other.

@camunda-cloud/sre This breaks the compatibility with `v1` but I guess we don't have too many deployments that are using it so:

* Either we live with the breaking change and we update our code :)
* Or we tag v1.1.0 and we use these tags from now on.