### PR TITLE
Authenticate using google-github-actions/auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,13 +44,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Google Cloud authentication
+      uses: google-github-actions/auth@v0.5.0
+      with:
+        credentials_json: ${{ inputs.service_account_key }}
+
     - name: Configure Google SDK
       uses: google-github-actions/setup-gcloud@v0.2.1
       with:
         version: ${{ inputs.gcloud_version }}
         project_id: ${{ inputs.project_id }}
-        service_account_key: ${{ inputs.service_account_key }}
-        export_default_credentials: true
 
     - name: Authenticate for Google Container Registry
       shell: bash


### PR DESCRIPTION
`google-github-actions/setup-gcloud` with the `service_account_key` setting is deprecated and raises a warning during execution, see https://github.com/google-github-actions/setup-gcloud#authentication-inputs

* The external interface of our Action doesn't change.
* `export_default_credentials` is now `create_credentials_file` in `google-github-actions/auth` and [defaults to `true`](https://github.com/google-github-actions/auth/blob/ac489d50bb70d86f5f140f3ab96624e9738b4244/action.yml#L55-L60).