### PR TITLE
chore(deps): upgrade all the Google GitHub Actions to latest releases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,6 @@ inputs:
     description: |
       Location of the GKE cluster (zonal or regional) to authenticate against.
 
-
   kustomize_version:
     required: false
     description: Version of Kustomize to install.
@@ -45,12 +44,12 @@ runs:
   using: composite
   steps:
     - name: Google Cloud authentication
-      uses: google-github-actions/auth@v0.5.0
+      uses: google-github-actions/auth@v0.6.0
       with:
         credentials_json: ${{ inputs.service_account_key }}
 
     - name: Configure Google SDK
-      uses: google-github-actions/setup-gcloud@v0.2.1
+      uses: google-github-actions/setup-gcloud@v0.5.0
       with:
         version: ${{ inputs.gcloud_version }}
         project_id: ${{ inputs.project_id }}
@@ -61,7 +60,7 @@ runs:
       run: gcloud auth configure-docker
 
     - name: Authenticate for GKE (regional cluster)
-      uses: google-github-actions/get-gke-credentials@v0.4.0
+      uses: google-github-actions/get-gke-credentials@v0.5.0
       with:
         cluster_name: ${{ inputs.gke_cluster_name }}
         location: ${{ inputs.gke_cluster_location }}


### PR DESCRIPTION
Dependabot doesn't know how to process this file correctly, and can't be
configured to do it automatically, for the time being.

See: https://github.com/dependabot/dependabot-core/issues/4178

I didn't see any compatibility break with the new versions.

`google-github-actions/setup-gcloud` has a new option for [installing specific `gcloud` components](https://github.com/google-github-actions/setup-gcloud/pull/399), but we don't need this for the time being.

* https://github.com/google-github-actions/auth/releases
* https://github.com/google-github-actions/get-gke-credentials/releases
* https://github.com/google-github-actions/setup-gcloud/releases