### PR TITLE
Make GKE authentication optional again

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,8 @@ runs:
       if: ${{ inputs.docker_auth == 'true'}}
       run: gcloud auth configure-docker
 
-    - name: Authenticate for GKE (regional cluster)
+    - name: Authenticate for GKE
+      if: ${{ inputs.gke_cluster_name != '' }}
       uses: google-github-actions/get-gke-credentials@v0.5.0
       with:
         cluster_name: ${{ inputs.gke_cluster_name }}


### PR DESCRIPTION
In 8e584194f549082fa2dbfeeafa59ce64e66d5156, I removed the condition on the GKE cluster name input and it's now not possible to simply authenticate against GCP without also authenticating against GKE.

This reverts the change and makes GKE authentication optional again.

I'll tag a new release `v1.2.0` and update `v1` after that.